### PR TITLE
fix invalid affiliation

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -11,7 +11,6 @@ creator:
   - givenName: Erik Play2Learn
     familyName: Bernoth
     type: Person
-    affiliation: ''
 keywords:
   - education
   - game


### PR DESCRIPTION
Using a string as affiliation is invalid. Please remove the empty string for a valid metadata.yml